### PR TITLE
Add multiline support to secondary_info

### DIFF
--- a/numberbox-card.js
+++ b/numberbox-card.js
@@ -187,7 +187,6 @@ static get styles() {
 		font-weight:var(--paper-font-body1_-_font-weight);
 		line-height:var(--paper-font-body1_-_line-height);
 		padding:4px 0}
-	.secondary{color:var(--secondary-text-color);}
 	state-badge{flex:0 0 40px;}
 	ha-card.noborder{padding:0 !important;margin:0 !important;
 		box-shadow:none !important;border:none !important}
@@ -233,6 +232,9 @@ static get styles() {
 	.grid-right {
 	  text-align: right
 	}
+	.secondary{
+           color:var(--secondary-text-color);
+           white-space: normal;}
 	`;
 }
 


### PR DESCRIPTION
My goal was something like this:

![1numberbox](https://user-images.githubusercontent.com/2511168/147856357-c785d8c9-9975-420e-9993-4abe543fb30c.png)
