### PR TITLE
Rules for `icon` & `picture` options added

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ or added by clicking the "Add to lovelace" button on the HACS dashboard after in
 | type | string | **Required** | `custom:numberbox-card`
 | entity | string | **Required** | `input_number.my_slider` or `number.my_number`
 | name | string/bool | `friendly_name` | Override friendly name (set to `false` to hide)
-| icon | string/bool | `icon` | Override icon (set to `false` to hide)
-| picture | string/bool | `entity_picture` | picture as icon eg. `/local/picture.png` local is www folder (set to `false` to hide)
+| icon | string/bool | `icon` | Override icon (set to `false` to hide) <br />Also check a ![rules' table below](https://github.com/htmltiger/numberbox-card/blob/main/README.md#how-icon--picture-options-work-dependingly-on-a-presense-of-icon--entity_picture-properties)
+| picture | string/bool | `entity_picture` | picture as icon eg. `/local/picture.png` local is www folder (set to `false` to hide) <br />Also check a ![rules' table below](https://github.com/htmltiger/numberbox-card/blob/main/README.md#how-icon--picture-options-work-dependingly-on-a-presense-of-icon--entity_picture-properties)
 | border | bool | `false` | set to `true` to show borders
 | icon_plus | string | `mdi:plus` | custom icon
 | icon_minus | string | `mdi:minus` | custom icon
@@ -127,6 +127,9 @@ entities:
       Mode:<b style="color:red"> %climate.downstairs_heating:attributes:hvac_action </b><br />
       Current temp:<b style="color:green"> %climate.downstairs_heating:attributes:current_temperature </b>
 ```
+
+#### How `icon` & `picture` options work dependingly on a presense of `icon` & `entity_picture` properties
+![image](https://user-images.githubusercontent.com/71872483/187812716-689ed7ef-9019-446f-b212-7249f1a3f170.png)
 
 
 ## Examples


### PR DESCRIPTION
Added some clarifications regarding `icon` & `picture` options.
Basically a table from [this comment](https://github.com/htmltiger/numberbox-card/issues/59#issuecomment-1233618052).

Fill free to decide if these clarifications are helpful.
